### PR TITLE
Order addItem endpoint implements MQTT

### DIFF
--- a/order/go.mod
+++ b/order/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.12.1 // indirect
@@ -24,12 +25,12 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.4 // indirect
 	github.com/klauspost/compress v1.15.0 // indirect
-	github.com/mattn/go-colorable v0.1.7 // indirect
-	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/lithammer/shortuuid v3.0.0+incompatible // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.37.0 // indirect
 	github.com/valyala/tcplisten v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	golang.org/x/text v0.3.7 // indirect
 )

--- a/order/utils/mqtt.go
+++ b/order/utils/mqtt.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"fmt"
-	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
@@ -49,7 +48,7 @@ func Publish(payload interface{}, client mqtt.Client, topic string) {
 	fmt.Printf("\npublishing to topic: %v with payload: %v\n", topic, payload)
 	token := client.Publish(topic, 0, true, payload)
 	token.Wait()
-	time.Sleep(time.Second)
+	//time.Sleep(time.Second)
 }
 
 func Subscribe(client mqtt.Client, topic string) {

--- a/stock/utils/database.go
+++ b/stock/utils/database.go
@@ -32,11 +32,5 @@ func OpenPsqlConnection() *gorm.DB {
 	if errDb != nil && errMg != nil {
 		return nil
 	}
-	defer db.Close()
-
-	err = db.Ping()
-	if err != nil {
-		return "connection failed"
-	}
-	return "connection open"
+	return db
 }


### PR DESCRIPTION
I made a proof of concept of how to implement the MQTT communication.
I implemented it for the addItem enpoint

- stock service subscribes to /subtractStock messages
https://github.com/mirunabetianu/WSM-Project/blob/540b416a816e97a149f600a3e9a86835e43f508d/stock/main.go#L37
- order service subscribes to /response messages
https://github.com/mirunabetianu/WSM-Project/blob/540b416a816e97a149f600a3e9a86835e43f508d/order/main.go#L48
- http call to /addItem happens
- order service publishes a /subtractStock message to the broker with item id, amount to remove (alway 1) and a unique id. then waits for a new /response message or time-out
https://github.com/mirunabetianu/WSM-Project/blob/540b416a816e97a149f600a3e9a86835e43f508d/order/main.go#L154-L166
- stock service receives the /subtractStock and removes stock and publishes a /response messge with the message id and the response
- order service receives the /response message, ends the loop in the request and returns the response of the stock service
